### PR TITLE
CHORE-000: Replace interactions with backend with the useBackend hook.

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API=http://localhost:5000

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import Router from './router/Router';
 
 export default function App() {
+  console.log(process.env.REACT_APP_API);
   return (
     <div className="App">
       <Router></Router>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,6 @@
 import Router from './router/Router';
 
 export default function App() {
-  console.log(process.env.REACT_APP_API);
   return (
     <div className="App">
       <Router></Router>

--- a/frontend/src/contexts/backend/Admin.tsx
+++ b/frontend/src/contexts/backend/Admin.tsx
@@ -23,12 +23,13 @@ export interface Admin {
   deleteUser: (userID: { userID: number }) => Promise<Response>;
 }
 
-export const admin = (client: string): Admin => {
+export const admin = (client: string, validateResponse: (response: any) => void): Admin => {
   const getAllUsers = async () => {
     const request = await fetch(`${client}/user/`, {
       method: 'GET',
       headers: { Authorization: `bearer ${localStorage.getItem('token')}` }
     });
+    validateResponse(request);
     const response = (await request.json()) as User[];
     return response;
   };
@@ -56,7 +57,7 @@ export const admin = (client: string): Admin => {
       },
       body: JSON.stringify({ userID, name, email, role })
     });
-
+    validateResponse(request);
     const response = (await request.json()) as Response;
     return response;
   };
@@ -66,7 +67,7 @@ export const admin = (client: string): Admin => {
       method: 'DELETE',
       headers: { Authorization: `bearer ${localStorage.token}` }
     });
-
+    validateResponse(request);
     const response = (await request.json()) as Response;
     return response;
   };

--- a/frontend/src/contexts/backend/Admin.tsx
+++ b/frontend/src/contexts/backend/Admin.tsx
@@ -1,13 +1,11 @@
-import { api } from '../../utils/api';
-
-export interface User {
+interface User {
   userID: number;
   name: string;
   role: string;
   email: string;
 }
 
-export interface Response {
+interface Response {
   status: boolean;
   message: string;
   error: string;
@@ -25,51 +23,53 @@ export interface Admin {
   deleteUser: (userID: { userID: number }) => Promise<Response>;
 }
 
-const getAllUsers = async () => {
-  const request = await fetch(`${api}/user/`, {
-    method: 'GET',
-    headers: { Authorization: `bearer ${localStorage.getItem('token')}` }
-  });
-  const response = (await request.json()) as User[];
-  return response;
+export const admin = (client: string): Admin => {
+  const getAllUsers = async () => {
+    const request = await fetch(`${client}/user/`, {
+      method: 'GET',
+      headers: { Authorization: `bearer ${localStorage.getItem('token')}` }
+    });
+    const response = (await request.json()) as User[];
+    return response;
+  };
+
+  const addUser = async (user: { name: string; email: string; role: string; password: string }) => {
+    const request = await fetch(`${client}/user/`, {
+      method: 'POST',
+      headers: {
+        Authorization: `bearer ${localStorage.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(user)
+    });
+    const response = (await request.json()) as Response;
+    return response;
+  };
+
+  const changeRole = async (user: User, role: string) => {
+    const { userID, name, email } = user;
+    const request = await fetch(`${client}/user/${userID}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `bearer ${localStorage.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ userID, name, email, role })
+    });
+
+    const response = (await request.json()) as Response;
+    return response;
+  };
+
+  const deleteUser = async ({ userID }: { userID: number }) => {
+    const request = await fetch(`${client}/user/${userID}`, {
+      method: 'DELETE',
+      headers: { Authorization: `bearer ${localStorage.token}` }
+    });
+
+    const response = (await request.json()) as Response;
+    return response;
+  };
+
+  return { getAllUsers, addUser, changeRole, deleteUser };
 };
-
-const addUser = async (user: { name: string; email: string; role: string; password: string }) => {
-  const request = await fetch(`${api}/user/`, {
-    method: 'POST',
-    headers: {
-      Authorization: `bearer ${localStorage.token}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify(user)
-  });
-  const response = (await request.json()) as Response;
-  return response;
-};
-
-const changeRole = async (user: User, role: string) => {
-  const { userID, name, email } = user;
-  const request = await fetch(`${api}/user/${userID}`, {
-    method: 'PUT',
-    headers: {
-      Authorization: `bearer ${localStorage.token}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ userID, name, email, role })
-  });
-
-  const response = (await request.json()) as Response;
-  return response;
-};
-
-const deleteUser = async ({ userID }: { userID: number }) => {
-  const request = await fetch(`${api}/user/${userID}`, {
-    method: 'DELETE',
-    headers: { Authorization: `bearer ${localStorage.token}` }
-  });
-
-  const response = (await request.json()) as Response;
-  return response;
-};
-
-export const admin: Admin = { getAllUsers, addUser, changeRole, deleteUser };

--- a/frontend/src/contexts/backend/Backend.tsx
+++ b/frontend/src/contexts/backend/Backend.tsx
@@ -2,25 +2,31 @@ import { createContext, useContext } from 'react';
 import { inventory, Inventory } from './Inventory';
 import { Manufacturing, manufacturing } from './Manufacturing';
 import { admin, Admin } from './Admin';
+import { planning, Planning } from './Planning';
 
 interface Backend {
   inventory: Inventory;
   manufacturing: Manufacturing;
   admin: Admin;
+  planning: Planning;
 }
 
 const BackendContext = createContext<Backend | undefined>(undefined);
 
 interface Props {
+  client: string;
   children?: React.ReactNode;
 }
 
-export const BackendProvider = ({ children }: Props) => {
-  return (
-    <BackendContext.Provider value={{ inventory, manufacturing, admin }}>
-      {children}
-    </BackendContext.Provider>
-  );
+export const BackendProvider = ({ client, children }: Props) => {
+  const backend = {
+    admin: admin(client),
+    inventory: inventory(client),
+    manufacturing: manufacturing(client),
+    planning: planning(client)
+  };
+
+  return <BackendContext.Provider value={backend}>{children}</BackendContext.Provider>;
 };
 
 export const useBackend = () => useContext(BackendContext) as Backend;

--- a/frontend/src/contexts/backend/Customers.tsx
+++ b/frontend/src/contexts/backend/Customers.tsx
@@ -1,5 +1,3 @@
-import { api } from '../../utils/api';
-
 export interface Customer {
   name: string;
   email: string;
@@ -16,26 +14,30 @@ export interface Customers {
   addCustomer: (customer: { name: string; email: string }) => Promise<CustomerResponse>;
 }
 
-const getAllCustomers = async () => {
-  const request = await fetch(`${api}/customer`, {
-    method: 'GET',
-    headers: { Authorization: `bearer ${localStorage.getItem('token')}` }
-  });
-  const response = (await request.json()) as CustomerResponse[];
-  return response;
-};
+export const customer = (client: string, validateResponse: (response: any) => void): Customers => {
+  const getAllCustomers = async () => {
+    const request = await fetch(`${client}/customer`, {
+      method: 'GET',
+      headers: { Authorization: `bearer ${localStorage.getItem('token')}` }
+    });
+    validateResponse(request);
+    const response = (await request.json()) as CustomerResponse[];
+    return response;
+  };
 
-const addCustomer = async (customer: { name: string; email: string }) => {
-  const request = await fetch(`${api}/customer`, {
-    method: 'POST',
-    headers: {
-      Authorization: `bearer ${localStorage.token}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify(customer)
-  });
-  const response = (await request.json()) as CustomerResponse;
-  return response;
-};
+  const addCustomer = async (customer: { name: string; email: string }) => {
+    const request = await fetch(`${client}/customer`, {
+      method: 'POST',
+      headers: {
+        Authorization: `bearer ${localStorage.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(customer)
+    });
+    validateResponse(request);
+    const response = (await request.json()) as CustomerResponse;
+    return response;
+  };
 
-export const customer: Customers = { getAllCustomers, addCustomer };
+  return { getAllCustomers, addCustomer };
+};

--- a/frontend/src/contexts/backend/Inventory.tsx
+++ b/frontend/src/contexts/backend/Inventory.tsx
@@ -1,8 +1,8 @@
 import { Item } from '../../interfaces/Items';
-import { api } from '../../utils/api';
 
 export interface Inventory {
   getAllGoods: () => Promise<Item[]>;
+  addGood: (good: FinishedGoodData | SemiFinishedGoodData | RawMaterialData) => Promise<Response>;
   getGood: (id: string | number) => Promise<{ schema: Item }>;
   archiveGood: (id: number | string) => Promise<Response[]>;
 }
@@ -12,34 +12,102 @@ interface Response {
   message: string;
 }
 
-const getAllGoods = async () => {
-  const request = await fetch(`${api}/good/`, {
-    headers: { Authorization: `bearer ${localStorage.token}` }
-  });
-  const response = await request.json();
-  return response.message as Item[];
+interface Good {
+  id: number;
+  name: string;
+  quantity: number;
+  cost: number;
+  type: 'raw' | 'semi-finished' | 'finished';
+  vendor: string;
+  processTime: number;
+  properties: Property[];
+  components: Component[];
+  price: number;
+}
+
+interface Component {
+  id: number;
+  name: string;
+  quantity: number;
+}
+
+interface Property {
+  name: string;
+  value: string;
+}
+
+interface FinishedGoodData {
+  name?: string;
+  type?: 'finished';
+  cost?: number;
+  price?: number;
+  components?: Component[];
+  processTime?: number;
+  properties?: Property[];
+}
+
+interface SemiFinishedGoodData {
+  name?: string;
+  type?: 'semi-finished';
+  components?: Component[];
+  processTime?: number;
+  properties?: Property[];
+  cost?: number;
+}
+
+interface RawMaterialData {
+  name?: string;
+  type?: 'raw';
+  cost?: number;
+  vendor?: string;
+  processTime?: number;
+  properties?: Property[];
+}
+
+export const inventory = (client: string): Inventory => {
+  const getAllGoods = async () => {
+    const request = await fetch(`${client}/good/`, {
+      headers: { Authorization: `bearer ${localStorage.token}` }
+    });
+    const response = await request.json();
+    return response.message as Good[];
+  };
+
+  const addGood = async (good: FinishedGoodData | SemiFinishedGoodData | RawMaterialData) => {
+    const request = await fetch(`${client}/good/single`, {
+      method: 'POST',
+      headers: {
+        Authorization: `bearer ${localStorage.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(good)
+    });
+
+    const response = await request.json();
+    return response;
+  };
+
+  const getGood = async (id: number | string) => {
+    const request = await fetch(`${client}/good/id/${id}`, {
+      headers: { Authorization: `bearer ${localStorage.token}` }
+    });
+    const response = await request.json();
+    return response.message as { schema: Good };
+  };
+
+  const archiveGood = async (id: number | string) => {
+    const request = await fetch(`${client}/good/archive`, {
+      method: 'POST',
+      headers: {
+        Authorization: `bearer ${localStorage.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify([{ id: Number(id), archive: true }])
+    });
+
+    const responses = (await request.json()) as Response[];
+    return responses;
+  };
+
+  return { getAllGoods, getGood, addGood, archiveGood };
 };
-
-const getGood = async (id: number | string) => {
-  const request = await fetch(`${api}/good/id/${id}`, {
-    headers: { Authorization: `bearer ${localStorage.token}` }
-  });
-  const response = await request.json();
-  return response.message as { schema: Item };
-};
-
-const archiveGood = async (id: number | string) => {
-  const request = await fetch(`${api}/good/archive`, {
-    method: 'POST',
-    headers: {
-      Authorization: `bearer ${localStorage.token}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify([{ id: Number(id), archive: true }])
-  });
-
-  const responses = (await request.json()) as Response[];
-  return responses;
-};
-
-export const inventory: Inventory = { getAllGoods, getGood, archiveGood };

--- a/frontend/src/contexts/backend/Inventory.tsx
+++ b/frontend/src/contexts/backend/Inventory.tsx
@@ -65,11 +65,12 @@ interface RawMaterialData {
   properties?: Property[];
 }
 
-export const inventory = (client: string): Inventory => {
+export const inventory = (client: string, validateResponse: (response: any) => void): Inventory => {
   const getAllGoods = async () => {
     const request = await fetch(`${client}/good/`, {
       headers: { Authorization: `bearer ${localStorage.token}` }
     });
+    validateResponse(request);
     const response = await request.json();
     return response.message as Good[];
   };
@@ -83,7 +84,7 @@ export const inventory = (client: string): Inventory => {
       },
       body: JSON.stringify(good)
     });
-
+    validateResponse(request);
     const response = await request.json();
     return response;
   };
@@ -92,6 +93,7 @@ export const inventory = (client: string): Inventory => {
     const request = await fetch(`${client}/good/id/${id}`, {
       headers: { Authorization: `bearer ${localStorage.token}` }
     });
+    validateResponse(request);
     const response = await request.json();
     return response.message as { schema: Good };
   };
@@ -105,7 +107,7 @@ export const inventory = (client: string): Inventory => {
       },
       body: JSON.stringify([{ id: Number(id), archive: true }])
     });
-
+    validateResponse(request);
     const responses = (await request.json()) as Response[];
     return responses;
   };
@@ -114,6 +116,7 @@ export const inventory = (client: string): Inventory => {
     const request = await fetch(`${client}/good/type/finished`, {
       headers: { Authorization: `bearer ${localStorage.token}` }
     });
+    validateResponse(request);
     const response = await request.json();
     return response.message as Item[];
   };

--- a/frontend/src/contexts/backend/Manufacturing.tsx
+++ b/frontend/src/contexts/backend/Manufacturing.tsx
@@ -29,11 +29,15 @@ export interface Manufacturing {
     orders: [id: number]
   ) => Promise<Response[]>;
 }
-export const manufacturing = (client: string): Manufacturing => {
+export const manufacturing = (
+  client: string,
+  validateResponse: (response: any) => void
+): Manufacturing => {
   const getAllOrders = async () => {
     const request = await fetch(`${client}/manufacturing/order`, {
       headers: { Authorization: `bearer ${localStorage.token}` }
     });
+    validateResponse(request);
     const response = await request.json();
     return response.message as Orders[];
   };
@@ -42,6 +46,7 @@ export const manufacturing = (client: string): Manufacturing => {
     const request = await fetch(`${client}/manufacturing/order/id/${id}`, {
       headers: { Authorization: `bearer ${localStorage.token}` }
     });
+    validateResponse(request);
     return ((await request.json()) as any).message as Orders;
   };
 
@@ -54,7 +59,7 @@ export const manufacturing = (client: string): Manufacturing => {
       },
       body: JSON.stringify(orders)
     });
-
+    validateResponse(request);
     const response: Response = await request.json();
     return response;
   };
@@ -71,7 +76,7 @@ export const manufacturing = (client: string): Manufacturing => {
       },
       body: JSON.stringify(orders)
     });
-
+    validateResponse(request);
     const responses: Response[] = await request.json();
     return responses;
   };

--- a/frontend/src/contexts/backend/Manufacturing.tsx
+++ b/frontend/src/contexts/backend/Manufacturing.tsx
@@ -1,9 +1,23 @@
-import { Orders } from '../../interfaces/Orders';
-import { api } from '../../utils/api';
-
 interface Response {
   status: boolean;
   message: string;
+}
+
+interface Orders {
+  orderId: number;
+  status: 'processing' | 'completed' | 'confirmed';
+  cost: number;
+  creationDate: string;
+  startDate: string;
+  estimatedEndDate: string;
+  completionDate: string;
+  orderedGoods: OrderedGoods[];
+}
+
+interface OrderedGoods {
+  id: number;
+  cost: number;
+  quantity: number;
 }
 
 export interface Manufacturing {
@@ -15,51 +29,52 @@ export interface Manufacturing {
     orders: [id: number]
   ) => Promise<Response[]>;
 }
+export const manufacturing = (client: string): Manufacturing => {
+  const getAllOrders = async () => {
+    const request = await fetch(`${client}/manufacturing/order`, {
+      headers: { Authorization: `bearer ${localStorage.token}` }
+    });
+    const response = await request.json();
+    return response.message as Orders[];
+  };
 
-const getAllOrders = async () => {
-  const request = await fetch(`${api}/manufacturing/order`, {
-    headers: { Authorization: `bearer ${localStorage.token}` }
-  });
-  const response = await request.json();
-  return response.message as Orders[];
+  const getOrder = async (id: number | string) => {
+    const request = await fetch(`${client}/manufacturing/order/id/${id}`, {
+      headers: { Authorization: `bearer ${localStorage.token}` }
+    });
+    return ((await request.json()) as any).message as Orders;
+  };
+
+  const createOrder = async (orders: [{ compositeId: number; quantity: number }]) => {
+    const request = await fetch(`${client}/manufacturing/order/`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `bearer ${localStorage.token}`
+      },
+      body: JSON.stringify(orders)
+    });
+
+    const response: Response = await request.json();
+    return response;
+  };
+
+  const updateStatus = async (
+    status: 'confirmed' | 'cancelled' | 'processing' | 'completed',
+    orders: [id: number]
+  ) => {
+    const request = await fetch(`${client}/manufacturing/order/${status}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `bearer ${localStorage.token}`
+      },
+      body: JSON.stringify(orders)
+    });
+
+    const responses: Response[] = await request.json();
+    return responses;
+  };
+
+  return { getAllOrders, getOrder, createOrder, updateStatus };
 };
-
-const getOrder = async (id: number | string) => {
-  const request = await fetch(`${api}/manufacturing/order/id/${id}`, {
-    headers: { Authorization: `bearer ${localStorage.token}` }
-  });
-  return ((await request.json()) as any).message as Orders;
-};
-
-const createOrder = async (orders: [{ compositeId: number; quantity: number }]) => {
-  const request = await fetch(`${api}/manufacturing/order/`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `bearer ${localStorage.token}`
-    },
-    body: JSON.stringify(orders)
-  });
-
-  const response: Response = await request.json();
-  return response;
-};
-
-const updateStatus = async (
-  status: 'confirmed' | 'cancelled' | 'processing' | 'completed',
-  orders: [id: number]
-) => {
-  const request = await fetch(`${api}/manufacturing/order/${status}`, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `bearer ${localStorage.token}`
-    },
-    body: JSON.stringify(orders)
-  });
-
-  const responses: Response[] = await request.json();
-  return responses;
-};
-
-export const manufacturing: Manufacturing = { getAllOrders, getOrder, createOrder, updateStatus };

--- a/frontend/src/contexts/backend/Planning.tsx
+++ b/frontend/src/contexts/backend/Planning.tsx
@@ -1,0 +1,185 @@
+interface Response {
+  status: boolean;
+  message: string;
+}
+
+interface Event {
+  id: number;
+  date: string;
+  time: string;
+  title: string;
+}
+
+interface Goal {
+  id: number;
+  completed: boolean;
+  targetDate: string;
+  title: string;
+}
+
+export interface Planning {
+  // Events
+  getAllEvents: () => Promise<Event[]>;
+  addEvent: (date: string, time: string, title: string) => Promise<Response>;
+  deleteEvent: (id: string | number) => Promise<Response>;
+
+  // Goals
+  getAllGoals: () => Promise<Goal[]>;
+  addGoal: (title: string, targetDate: string) => Promise<Response>;
+  updateGoal: (
+    id: string | number,
+    completed: boolean,
+    targetDate: string,
+    title: string
+  ) => Promise<Response>;
+  deleteGoal: (id: string | number) => Promise<Response>;
+}
+
+export const planning = (client: string): Planning => {
+  // ***************************************
+  // EVENTS
+  // ***************************************
+
+  /**
+   * Get all events.
+   * @returns A list of events.
+   */
+  const getAllEvents = async () => {
+    const request = await fetch(`${client}/planning/events`, {
+      headers: { Authorization: `bearer ${localStorage.token}` }
+    });
+    const response = await request.json();
+    const events = response.message as Event[];
+    return events;
+  };
+
+  /**
+   * Create a new event.
+   * @param date Date of the event with format ``yyyy-mm-dd``.
+   * @param time Time of the event with format ``hh:mm:ss``.
+   * @param title Title of the event.
+   * @returns The validation response.
+   */
+  const addEvent = async (date: string, time: string, title: string) => {
+    const request = await fetch(`${client}/planning/events`, {
+      method: 'POST',
+      headers: {
+        Authorization: `bearer ${localStorage.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ date, time, title })
+    });
+
+    const response = (await request.json()) as Response;
+    return response;
+  };
+
+  /**
+   * Delete an event.
+   * @param id The ID of the event.
+   * @returns The validation response.
+   */
+  const deleteEvent = async (id: string | number) => {
+    const request = await fetch(`${client}/planning/events/${id}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `bearer ${localStorage.token}`,
+        'Content-Type': 'application/json'
+      }
+    });
+
+    const response = (await request.json()) as Response;
+    return response;
+  };
+
+  // ***************************************
+  // GOALS
+  // ***************************************
+
+  /**
+   * Get all goals.
+   * @returns A list of goals.
+   */
+  const getAllGoals = async () => {
+    const request = await fetch(`${client}/planning/goals`, {
+      headers: { Authorization: `bearer ${localStorage.token}` }
+    });
+    const response = await request.json();
+    const goals = response.message as Goal[];
+    return goals;
+  };
+
+  /**
+   * Create a new goal.
+   * @param title Title of the goal.
+   * @param targetDate Date of the goal with format ``yyyy-mm-dd``.
+   * @returns The validation response.
+   */
+  const addGoal = async (title: string, targetDate: string) => {
+    const request = await fetch(`${client}/planning/goals`, {
+      method: 'POST',
+      headers: {
+        Authorization: `bearer ${localStorage.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ title, targetDate })
+    });
+
+    const response = (await request.json()) as Response;
+    return response;
+  };
+
+  /**
+   * Update a goal.
+   * @param id The ID of the goal.
+   * @param complete Whether the goal is completed or not.
+   * @param title Title of the goal.
+   * @param targetDate Date of the goal with format ``yyyy-mm-dd``.
+   * @returns The validation response.
+   */
+  const updateGoal = async (
+    id: string | number,
+    completed: boolean,
+    targetDate: string,
+    title: string
+  ) => {
+    const request = await fetch(`${client}/planning/goals/${id}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `bearer ${localStorage.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ id, completed, targetDate, title })
+    });
+    const response = (await request.json()) as Response;
+    return response;
+  };
+
+  /**
+   * Delete a goal.
+   * @param id The ID of the goal.
+   * @returns The validation response.
+   */
+  const deleteGoal = async (id: string | number) => {
+    const request = await fetch(`${client}/planning/goals/${id}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `bearer ${localStorage.token}`,
+        'Content-Type': 'application/json'
+      }
+    });
+
+    const response = (await request.json()) as Response;
+    return response;
+  };
+
+  return {
+    getAllEvents,
+    addEvent,
+    deleteEvent,
+    getAllGoals,
+    addGoal,
+    updateGoal,
+    deleteGoal
+  };
+};

--- a/frontend/src/contexts/backend/Planning.tsx
+++ b/frontend/src/contexts/backend/Planning.tsx
@@ -35,7 +35,7 @@ export interface Planning {
   deleteGoal: (id: string | number) => Promise<Response>;
 }
 
-export const planning = (client: string): Planning => {
+export const planning = (client: string, validateResponse: (response: any) => void): Planning => {
   // ***************************************
   // EVENTS
   // ***************************************
@@ -48,6 +48,7 @@ export const planning = (client: string): Planning => {
     const request = await fetch(`${client}/planning/events`, {
       headers: { Authorization: `bearer ${localStorage.token}` }
     });
+    validateResponse(request);
     const response = await request.json();
     const events = response.message as Event[];
     return events;
@@ -69,7 +70,7 @@ export const planning = (client: string): Planning => {
       },
       body: JSON.stringify({ date, time, title })
     });
-
+    validateResponse(request);
     const response = (await request.json()) as Response;
     return response;
   };
@@ -87,7 +88,7 @@ export const planning = (client: string): Planning => {
         'Content-Type': 'application/json'
       }
     });
-
+    validateResponse(request);
     const response = (await request.json()) as Response;
     return response;
   };
@@ -104,6 +105,7 @@ export const planning = (client: string): Planning => {
     const request = await fetch(`${client}/planning/goals`, {
       headers: { Authorization: `bearer ${localStorage.token}` }
     });
+    validateResponse(request);
     const response = await request.json();
     const goals = response.message as Goal[];
     return goals;
@@ -124,7 +126,7 @@ export const planning = (client: string): Planning => {
       },
       body: JSON.stringify({ title, targetDate })
     });
-
+    validateResponse(request);
     const response = (await request.json()) as Response;
     return response;
   };
@@ -151,6 +153,7 @@ export const planning = (client: string): Planning => {
       },
       body: JSON.stringify({ id, completed, targetDate, title })
     });
+    validateResponse(request);
     const response = (await request.json()) as Response;
     return response;
   };
@@ -168,7 +171,7 @@ export const planning = (client: string): Planning => {
         'Content-Type': 'application/json'
       }
     });
-
+    validateResponse(request);
     const response = (await request.json()) as Response;
     return response;
   };

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from '@material-ui/core';
@@ -15,7 +14,7 @@ ReactDOM.render(
   <ThemeProvider theme={Theme}>
     <SnackbarProvider>
       <AuthProvider>
-        <BackendProvider>
+        <BackendProvider client={process.env.REACT_APP_API ?? 'https://supreme-erp.herokuapp.com'}>
           <BrowserRouter>
             <App />
           </BrowserRouter>

--- a/frontend/src/pages/inventory/Inventory.tsx
+++ b/frontend/src/pages/inventory/Inventory.tsx
@@ -15,12 +15,12 @@ import {
 import { Search } from '@material-ui/icons/';
 
 import { Card, Progress } from '../../components';
-import { API_GOOD } from '../../utils/api';
 import ImportButton from './csv-impex/csv-import';
 import ExportButton from './csv-impex/csv-export';
 import { Item } from '../../interfaces/Items';
 import ItemRow from './item-row/ItemRow';
 import './Inventory.scss';
+import { useBackend } from '../../contexts';
 
 interface TableState {
   allOpen: boolean;
@@ -47,15 +47,12 @@ export default function Inventory() {
     typeFilter: 0,
     search: ''
   });
+  const { inventory } = useBackend();
 
   const filters = ['None', 'Raw', 'Semi-finished', 'Finished'];
 
   const getItems = async () => {
-    const request = await fetch(API_GOOD, {
-      headers: { Authorization: `bearer ${localStorage.token}` }
-    });
-    const response = await request.json();
-    const items = response.message as Item[];
+    const items = await inventory.getAllGoods();
     setItems(items.sort(sortItemsByType));
   };
 
@@ -74,6 +71,7 @@ export default function Inventory() {
 
   useEffect(() => {
     getItems();
+    //eslint-disable-next-line
   }, []);
 
   return items === undefined ? (

--- a/frontend/src/pages/inventory/csv-impex/csv-export.tsx
+++ b/frontend/src/pages/inventory/csv-impex/csv-export.tsx
@@ -1,23 +1,21 @@
-import React from 'react';
 import { Button } from '@material-ui/core';
 import { saveAs } from 'file-saver';
 import { jsonToCSV } from 'react-papaparse';
-import { API_GOOD } from '../../../utils/api';
+import { useBackend } from '../../../contexts';
 
 export default function ExportButton() {
+  const { inventory } = useBackend();
+
   const toCSV = async () => {
-    const request = await fetch(API_GOOD, {
-      method: 'GET',
-      headers: { Authorization: `bearer ${localStorage.token}` }
-    });
-    const response = await request.json();
-    for (var key in response.message) {
-      // Get object
-      let obj = response.message[key];
+    const goods = await inventory.getAllGoods();
+    for (var key in goods) {
+      // Creates a shallow copy of the good to give it new properties without
+      // being constained by the type of the good.
+      const obj: any = goods[key];
       obj['components'] = JSON.stringify(obj['components']);
       obj['properties'] = JSON.stringify(obj['properties']);
     }
-    const csv = jsonToCSV(response.message);
+    const csv = jsonToCSV(goods);
     const file = new File([csv], 'ModelData.csv', { type: '.csv' });
     saveAs(file);
   };

--- a/frontend/src/pages/manufacturing/Manufacturing.tsx
+++ b/frontend/src/pages/manufacturing/Manufacturing.tsx
@@ -2,21 +2,18 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
 import { Orders } from '../../interfaces/Orders';
-import { API_MAN } from '../../utils/api';
 import { Card } from '../../components';
 import './Manufacturing.scss';
 import OrderRow from './order-row/OrderRow';
+import { useBackend } from '../../contexts';
 
 export default function Manufacturing() {
   const [orders, setOrders] = useState<Orders[]>([]);
+  const { manufacturing } = useBackend();
 
   // Get orders from backend
   const getOrders = async () => {
-    const request = await fetch(API_MAN, {
-      headers: { Authorization: `bearer ${localStorage.token}` }
-    });
-    const response = await request.json();
-    const orders = response.message as Orders[];
+    const orders = await manufacturing.getAllOrders();
     setOrders(orders);
   };
 
@@ -29,6 +26,7 @@ export default function Manufacturing() {
   // Use orders from backend
   useEffect(() => {
     getOrders();
+    //eslint-disable-next-line
   }, []);
 
   return (

--- a/frontend/src/pages/planning/add-event/AddEvent.tsx
+++ b/frontend/src/pages/planning/add-event/AddEvent.tsx
@@ -3,46 +3,32 @@ import { Link, useHistory } from 'react-router-dom';
 
 import Event from '../shared/Event';
 import '../shared/AddForm.scss';
-import { API_ADD_EVENT } from '../../../utils/api';
-import { useSnackbar } from '../../../contexts';
-
-interface newEvent {
-  title?: string;
-  time?: string;
-  date?: string;
-}
+import { useSnackbar, useBackend } from '../../../contexts';
 
 export default function AddEvent() {
   const history = useHistory();
   const snackbar = useSnackbar();
+  const { planning } = useBackend();
 
   const addEvent = async (e: React.FormEvent) => {
     e.preventDefault();
     const form = e.target as HTMLFormElement;
-    const data = parseEvent(form);
+    const { title, time, date } = parseEvent(form);
 
-    const request = await fetch(API_ADD_EVENT, {
-      method: 'POST',
-      headers: {
-        Authorization: `bearer ${localStorage.token}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(data)
-    });
+    const response = await planning.addEvent(date, time, title);
 
-    const response = await request.json();
     if (response.status) {
       history.push('/planning');
-      snackbar.push(`${data?.title} has been saved`);
+      snackbar.push(`${title} has been saved`);
     }
   };
 
-  const parseEvent = (form: HTMLFormElement): newEvent => {
+  const parseEvent = (form: HTMLFormElement) => {
     const data = new FormData(form);
     return {
-      title: data.get('event-title') as string | undefined,
-      date: data.get('event-date') as string | undefined,
-      time: data.get('event-time') as string | undefined
+      title: data.get('event-title') as string,
+      date: data.get('event-date') as string,
+      time: data.get('event-time') as string
     };
   };
 

--- a/frontend/src/pages/planning/add-goal/AddGoal.tsx
+++ b/frontend/src/pages/planning/add-goal/AddGoal.tsx
@@ -3,44 +3,36 @@ import { Link, useHistory } from 'react-router-dom';
 
 import Goal from '../shared/Goal';
 import '../shared/AddForm.scss';
-import { API_ADD_GOAL } from '../../../utils/api';
-import { useSnackbar } from '../../../contexts';
+import { useBackend, useSnackbar } from '../../../contexts';
 
 interface newGoal {
-  title?: string;
-  targetDate?: string;
+  title: string;
+  targetDate: string;
 }
 
 export default function AddGoal() {
   const history = useHistory();
   const snackbar = useSnackbar();
+  const { planning } = useBackend();
 
   const addGoal = async (e: React.FormEvent) => {
     e.preventDefault();
     const form = e.target as HTMLFormElement;
-    const data = parseGoal(form);
+    const { title, targetDate } = parseGoal(form);
 
-    const request = await fetch(API_ADD_GOAL, {
-      method: 'POST',
-      headers: {
-        Authorization: `bearer ${localStorage.token}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(data)
-    });
+    const response = await planning.addGoal(title, targetDate);
 
-    const response = await request.json();
     if (response.status) {
       history.push('/planning');
-      snackbar.push(`${data?.title} has been saved`);
+      snackbar.push(`${title} has been saved`);
     }
   };
 
   const parseGoal = (form: HTMLFormElement): newGoal => {
     const data = new FormData(form);
     return {
-      title: data.get('goal-title') as string | undefined,
-      targetDate: data.get('goal-date') as string | undefined
+      title: data.get('goal-title') as string,
+      targetDate: data.get('goal-date') as string
     };
   };
 


### PR DESCRIPTION
# Description

After being annoyed by the countless, repetitive and confusing ``fetch(API, { method: 'POST', headers: {...}, body: {...})`` that spammed my components and made them harder to understand, I decided to replace them with a simple hook called ``useBackend``.

**Before:**

```js
const getAllGoods = async () => {
    const request = await fetch(API_GET_ALL_GOODS, {
      headers: { Authorization: `bearer ${localStorage.token}` }
    });
    const response = await request.json();
    const goods = response.message as Good[];
    setGoods(goods);
};
```

**Now:**

```js
const { inventory } = useBackend();

const getAllGoods = async () => {
    const goods = await inventory.getAllGoods();
    setGoods(goods);
};
```

You will agree with me that the new hook makes the components looks cleaner, more readable, and it makes chaining requests way less intimidating.

I also added the ``.env.development`` file so we don't use the production backend while testing our code.

## Type of change

- [X] CHORE (Something that needs to be done outside of the issue)

# Checklist:

- [X] My pull request references the issue in the comments
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

